### PR TITLE
Don't merge: Cannot add WhereTheWaterAlsoFlows to scripts/Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,8 +10,8 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-Plots = "1.5"
 Parameters = "0.12"
+Plots = "1.5"
 julia = "1.5"
 
 [extras]


### PR DESCRIPTION
Try
```
cd WhereTheWaterAlsoFlows
julia --project

...
]
add ..
```

This errors on my machine with
```
>> juliap
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.5.1 (2020-08-25)
 _/ |\__'_|_|_|\__'_|  |  
|__/                   |

(scripts) pkg> add ..
[ Info: Resolving package identifier `..` as a directory at `~/julia/dot-julia-dev/WhereTheWaterAlsoFlows`.
   Updating git-repo `/home/mauro/julia/dot-julia-dev/WhereTheWaterAlsoFlows`
   Updating registry at `~/.julia/registries/General`
   Updating git-repo `https://github.com/JuliaRegistries/General.git`
   Updating registry at `~/.julia/registries/MyTestPkgRegistry`
   Updating git-repo `git@github.com:mauro3/MyTestPkgRepository.git`
  Resolving package versions...
ERROR: Unsatisfiable requirements detected for package ParallelStencil [94395366]:
 ParallelStencil [94395366] log:
 ├─ParallelStencil [94395366] has no known versions!
 └─restricted to versions * by WhereTheWaterAlsoFlows [34c98889] — no versions left
   └─WhereTheWaterAlsoFlows [34c98889] log:
     ├─possible versions are: 0.1.0 or uninstalled
     └─WhereTheWaterAlsoFlows [34c98889] is fixed to version 0.1.0
```